### PR TITLE
Add referral QR code generation

### DIFF
--- a/app/handlers/referral.py
+++ b/app/handlers/referral.py
@@ -90,11 +90,19 @@ async def show_referral_info(
     
     referral_text += "📢 Приглашайте друзей и зарабатывайте!"
     
-    await callback.message.edit_text(
-        referral_text,
-        reply_markup=get_referral_keyboard(db_user.language),
-        parse_mode="HTML"
-    )
+    if callback.message.text:
+        await callback.message.edit_text(
+            referral_text,
+            reply_markup=get_referral_keyboard(db_user.language),
+            parse_mode="HTML"
+        )
+    else:
+        await callback.message.delete()
+        await callback.message.answer(
+            referral_text,
+            reply_markup=get_referral_keyboard(db_user.language),
+            parse_mode="HTML"
+        )
     await callback.answer()
 
 

--- a/app/handlers/referral.py
+++ b/app/handlers/referral.py
@@ -120,6 +120,7 @@ async def show_referral_qr(
         inline_keyboard=[[types.InlineKeyboardButton(text=texts.BACK, callback_data="menu_referrals")]]
     )
 
+    await callback.message.delete()
     await callback.message.answer_photo(
         photo,
         caption=f"🔗 Ваша реферальная ссылка:\n{referral_link}",

--- a/app/handlers/referral.py
+++ b/app/handlers/referral.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import qrcode
 from aiogram import Dispatcher, F, types
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import FSInputFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -128,12 +129,21 @@ async def show_referral_qr(
         inline_keyboard=[[types.InlineKeyboardButton(text=texts.BACK, callback_data="menu_referrals")]]
     )
 
-    await callback.message.delete()
-    await callback.message.answer_photo(
-        photo,
-        caption=f"🔗 Ваша реферальная ссылка:\n{referral_link}",
-        reply_markup=keyboard,
-    )
+    try:
+        await callback.message.edit_media(
+            types.InputMediaPhoto(
+                media=photo,
+                caption=f"🔗 Ваша реферальная ссылка:\n{referral_link}",
+            ),
+            reply_markup=keyboard,
+        )
+    except TelegramBadRequest:
+        await callback.message.delete()
+        await callback.message.answer_photo(
+            photo,
+            caption=f"🔗 Ваша реферальная ссылка:\n{referral_link}",
+            reply_markup=keyboard,
+        )
     await callback.answer()
 
 

--- a/app/handlers/referral.py
+++ b/app/handlers/referral.py
@@ -1,12 +1,20 @@
 import logging
-from aiogram import Dispatcher, types, F
+from pathlib import Path
+
+import qrcode
+from aiogram import Dispatcher, F, types
+from aiogram.types import FSInputFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database.models import User
-from app.keyboards.inline import get_referral_keyboard, get_back_keyboard
+from app.keyboards.inline import get_referral_keyboard
 from app.localization.texts import get_texts
-from app.utils.user_utils import get_user_referral_summary, get_detailed_referral_list, get_referral_analytics
+from app.utils.user_utils import (
+    get_detailed_referral_list,
+    get_referral_analytics,
+    get_user_referral_summary,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +94,36 @@ async def show_referral_info(
         referral_text,
         reply_markup=get_referral_keyboard(db_user.language),
         parse_mode="HTML"
+    )
+    await callback.answer()
+
+
+async def show_referral_qr(
+    callback: types.CallbackQuery,
+    db_user: User,
+):
+    texts = get_texts(db_user.language)
+
+    bot_username = (await callback.bot.get_me()).username
+    referral_link = f"https://t.me/{bot_username}?start={db_user.referral_code}"
+
+    qr_dir = Path("data") / "referral_qr"
+    qr_dir.mkdir(parents=True, exist_ok=True)
+
+    file_path = qr_dir / f"{db_user.id}.png"
+    if not file_path.exists():
+        img = qrcode.make(referral_link)
+        img.save(file_path)
+
+    photo = FSInputFile(file_path)
+    keyboard = types.InlineKeyboardMarkup(
+        inline_keyboard=[[types.InlineKeyboardButton(text=texts.BACK, callback_data="menu_referrals")]]
+    )
+
+    await callback.message.answer_photo(
+        photo,
+        caption=f"🔗 Ваша реферальная ссылка:\n{referral_link}",
+        reply_markup=keyboard,
     )
     await callback.answer()
 
@@ -242,6 +280,11 @@ def register_handlers(dp: Dispatcher):
     dp.callback_query.register(
         create_invite_message,
         F.data == "referral_create_invite"
+    )
+
+    dp.callback_query.register(
+        show_referral_qr,
+        F.data == "referral_show_qr"
     )
     
     dp.callback_query.register(

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -535,6 +535,12 @@ def get_referral_keyboard(language: str = "ru") -> InlineKeyboardMarkup:
         ],
         [
             InlineKeyboardButton(
+                text="📱 Показать QR код",
+                callback_data="referral_show_qr"
+            )
+        ],
+        [
+            InlineKeyboardButton(
                 text="👥 Список рефералов",
                 callback_data="referral_list"
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ APScheduler==3.10.4
 python-dateutil==2.8.2
 pytz==2023.4
 cryptography>=41.0.0
+qrcode[pil]==7.4.2


### PR DESCRIPTION
## Summary
- allow users to show their referral link as a QR code stored under `data`
- extend referral keyboard with a QR code button
- add QR code generation dependency

## Testing
- `pytest`
- `pip install qrcode[pil]` *(fails: Could not find a version that satisfies the requirement qrcode)*

------
https://chatgpt.com/codex/tasks/task_e_68bd57933aa08326aa54dd518b87aa27