### PR TITLE
feat: add top up prompt on insufficient balance

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -34,7 +34,8 @@ from app.keyboards.inline import (
     get_manage_countries_keyboard,
     get_device_selection_keyboard, get_connection_guide_keyboard,
     get_app_selection_keyboard, get_specific_app_keyboard,
-    get_subscription_settings_keyboard, get_extend_subscription_keyboard_with_prices
+    get_subscription_settings_keyboard, get_extend_subscription_keyboard_with_prices,
+    get_insufficient_balance_keyboard
 )
 from app.localization.texts import get_texts
 from app.services.remnawave_service import RemnaWaveService
@@ -1796,9 +1797,10 @@ async def confirm_purchase(
     logger.info(f"   ИТОГО: {final_price/100}₽")
     
     if db_user.balance_kopeks < final_price:
+        missing_kopeks = final_price - db_user.balance_kopeks
         await callback.message.edit_text(
-            texts.INSUFFICIENT_BALANCE,
-            reply_markup=get_back_keyboard(db_user.language)
+            texts.INSUFFICIENT_BALANCE.format(amount=texts.format_price(missing_kopeks)),
+            reply_markup=get_insufficient_balance_keyboard(db_user.language),
         )
         await callback.answer()
         return
@@ -1810,9 +1812,10 @@ async def confirm_purchase(
         )
         
         if not success:
+            missing_kopeks = final_price - db_user.balance_kopeks
             await callback.message.edit_text(
-                texts.INSUFFICIENT_BALANCE,
-                reply_markup=get_back_keyboard(db_user.language)
+                texts.INSUFFICIENT_BALANCE.format(amount=texts.format_price(missing_kopeks)),
+                reply_markup=get_insufficient_balance_keyboard(db_user.language),
             )
             await callback.answer()
             return

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -104,6 +104,19 @@ def get_back_keyboard(language: str = "ru") -> InlineKeyboardMarkup:
     ])
 
 
+def get_insufficient_balance_keyboard(language: str = "ru") -> InlineKeyboardMarkup:
+    texts = get_texts(language)
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [
+            InlineKeyboardButton(
+                text=texts.GO_TO_BALANCE_TOP_UP,
+                callback_data="balance_topup",
+            )
+        ],
+        [InlineKeyboardButton(text=texts.BACK, callback_data="back_to_menu")],
+    ])
+
+
 def get_subscription_keyboard(
     language: str = "ru", 
     has_subscription: bool = False, 

--- a/app/localization/texts.py
+++ b/app/localization/texts.py
@@ -204,7 +204,8 @@ class RussianTexts(Texts):
 Подтвердить покупку?
 """
     
-    INSUFFICIENT_BALANCE = "❌ Недостаточно средств на балансе. Пополните баланс и попробуйте снова."
+    INSUFFICIENT_BALANCE = "❌ Недостаточно средств на балансе. Пополните баланс на {amount} и попробуйте снова."
+    GO_TO_BALANCE_TOP_UP = "Перейти к пополнению баланса"
     SUBSCRIPTION_PURCHASED = "🎉 Подписка успешно приобретена!"
     
     BALANCE_INFO = """
@@ -443,10 +444,12 @@ To get started, select interface language:
     CONTINUE = "➡️ Continue"
     YES = "✅ Yes"
     NO = "❌ No"
-    
+
     MENU_BALANCE = "💰 Balance"
     MENU_SUBSCRIPTION = "📱 Subscription"
     MENU_TRIAL = "🎁 Trial subscription"
+    INSUFFICIENT_BALANCE = "❌ Insufficient balance. Top up {amount} and try again."
+    GO_TO_BALANCE_TOP_UP = "Go to balance top up"
     
 
 LANGUAGES = {


### PR DESCRIPTION
## Summary
- show required top-up amount when balance too low
- offer a button to top up balance directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd5e7e9448326aef7781320454fea