### PR TITLE
feat: add link connect button mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,7 @@ CRYPTOBOT_INVOICE_EXPIRES_HOURS=24
 # guide - открывает гайд подключения (режим 1)
 # miniapp_subscription - открывает ссылку подписки в мини-приложении (режим 2)
 # miniapp_custom - открывает заданную ссылку в мини-приложении (режим 3)
+# link - открывает ссылку подписки напрямую (режим 4)
 CONNECT_BUTTON_MODE=guide
 
 # URL для режима miniapp_custom (обязателен при CONNECT_BUTTON_MODE=miniapp_custom)

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ PAYMENT_SUBSCRIPTION_TEMPLATE={service_name} - {description}
 # guide - открывает гайд подключения (режим 1)
 # miniapp_subscription - открывает ссылку подписки в мини-приложении (режим 2)
 # miniapp_custom - открывает заданную ссылку в мини-приложении (режим 3)
+# link - открывает ссылку подписки напрямую (режим 4)
 CONNECT_BUTTON_MODE=guide
 
 # URL для режима miniapp_custom (обязателен при CONNECT_BUTTON_MODE=miniapp_custom)

--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -416,6 +416,12 @@ async def activate_trial(
                     [InlineKeyboardButton(text="📱 Моя подписка", callback_data="menu_subscription")],
                     [InlineKeyboardButton(text="⬅️ В главное меню", callback_data="back_to_menu")],
                 ])
+            elif connect_mode == "link":
+                connect_keyboard = InlineKeyboardMarkup(inline_keyboard=[
+                    [InlineKeyboardButton(text="🔗 Подключиться", url=subscription.subscription_url)],
+                    [InlineKeyboardButton(text="📱 Моя подписка", callback_data="menu_subscription")],
+                    [InlineKeyboardButton(text="⬅️ В главное меню", callback_data="back_to_menu")],
+                ])
             else:
                 connect_keyboard = InlineKeyboardMarkup(inline_keyboard=[
                     [InlineKeyboardButton(text="🔗 Подключиться", callback_data="subscription_connect")],
@@ -1920,6 +1926,12 @@ async def confirm_purchase(
                     [InlineKeyboardButton(text="📱 Моя подписка", callback_data="menu_subscription")],
                     [InlineKeyboardButton(text="⬅️ В главное меню", callback_data="back_to_menu")],
                 ])
+            elif connect_mode == "link":
+                connect_keyboard = InlineKeyboardMarkup(inline_keyboard=[
+                    [InlineKeyboardButton(text="🔗 Подключиться", url=subscription.subscription_url)],
+                    [InlineKeyboardButton(text="📱 Моя подписка", callback_data="menu_subscription")],
+                    [InlineKeyboardButton(text="⬅️ В главное меню", callback_data="back_to_menu")],
+                ])
             else:
                 connect_keyboard = InlineKeyboardMarkup(inline_keyboard=[
                     [InlineKeyboardButton(text="🔗 Подключиться", callback_data="subscription_connect")],
@@ -2687,7 +2699,30 @@ async def handle_connect_subscription(
             reply_markup=keyboard,
             parse_mode="HTML"
         )
-        
+
+    elif connect_mode == "link":
+        keyboard = InlineKeyboardMarkup(inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="🔗 Подключиться",
+                    url=subscription.subscription_url
+                )
+            ],
+            [
+                InlineKeyboardButton(text="⬅️ Назад", callback_data="menu_subscription")
+            ]
+        ])
+
+        await callback.message.edit_text(
+            f"""
+🚀 <b>Подключить подписку</b>
+
+🔗 Нажмите кнопку ниже, чтобы открыть ссылку подписки:
+            """,
+            reply_markup=keyboard,
+            parse_mode="HTML"
+        )
+
     else:
         device_text = f"""
 📱 <b>Подключить подписку</b>

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -163,6 +163,10 @@ def get_subscription_keyboard(
                     keyboard.append([
                         InlineKeyboardButton(text="🔗 Подключиться", callback_data="subscription_connect")
                     ])
+            elif connect_mode == "link":
+                keyboard.append([
+                    InlineKeyboardButton(text="🔗 Подключиться", url=subscription.subscription_url)
+                ])
             else:
                 keyboard.append([
                     InlineKeyboardButton(text="🔗 Подключиться", callback_data="subscription_connect")


### PR DESCRIPTION
## Summary
- support `CONNECT_BUTTON_MODE=link` to open subscription URLs directly
- document link mode in env example and README

## Testing
- `pytest`
- `python -m py_compile app/handlers/subscription.py app/keyboards/inline.py`


------
https://chatgpt.com/codex/tasks/task_e_68bffe09b2f88326af368c6ba2005122