### PR TITLE
Send VPN logo with every bot message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 !app/
 !app/**
 
+# Разрешаем папку assets/ и её содержимое
+!assets/
+!assets/**
+assets/vpn_logo.png
+
 # Дополнительно разрешаем README и лицензию (опционально)
 !README.md
 !LICENSE


### PR DESCRIPTION
## Summary
- extend gitignore to allow storing assets while ignoring `assets/vpn_logo.png`
- attach VPN logo to all bot messages via custom `LogoBot`

## Testing
- `python -m py_compile app/bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c05bd590348326a8289c580515791a