### PR TITLE
feat: allow skipping rules and referral prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,11 @@ CONNECT_BUTTON_MODE=guide
 # URL для режима miniapp_custom (обязателен при CONNECT_BUTTON_MODE=miniapp_custom)
 MINIAPP_CUSTOM_URL=
 
+# Пропустить принятие правил использования бота
+SKIP_RULES_ACCEPT=false
+# Пропустить запрос реферального кода
+SKIP_REFERRAL_CODE=false
+
 # ===== МОНИТОРИНГ И УВЕДОМЛЕНИЯ =====
 MONITORING_INTERVAL=60
 INACTIVE_USER_DELETE_MONTHS=3

--- a/app/config.py
+++ b/app/config.py
@@ -140,7 +140,9 @@ class Settings(BaseSettings):
     MINIAPP_CUSTOM_URL: str = ""
     ENABLE_LOGO_MODE: bool = True
     LOGO_FILE: str = "vpn_logo.png"
-    
+    SKIP_RULES_ACCEPT: bool = False
+    SKIP_REFERRAL_CODE: bool = False
+
     DEFAULT_LANGUAGE: str = "ru"
     AVAILABLE_LANGUAGES: str = "ru,en"
     


### PR DESCRIPTION
## Summary
- add SKIP_RULES_ACCEPT and SKIP_REFERRAL_CODE environment options
- adjust registration flow to respect skip flags

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3cc1d5f24832696eea34957ea8118