### PR TITLE
Add connect button to main menu

### DIFF
--- a/app/handlers/menu.py
+++ b/app/handlers/menu.py
@@ -42,9 +42,10 @@ async def show_main_menu(
             has_had_paid_subscription=db_user.has_had_paid_subscription,
             has_active_subscription=has_active_subscription,
             subscription_is_active=subscription_is_active,
-            balance_kopeks=db_user.balance_kopeks 
+            balance_kopeks=db_user.balance_kopeks,
+            subscription=db_user.subscription,
         ),
-        parse_mode="HTML" 
+        parse_mode="HTML"
     )
     await callback.answer()
 
@@ -119,7 +120,8 @@ async def handle_back_to_menu(
             has_had_paid_subscription=db_user.has_had_paid_subscription,
             has_active_subscription=has_active_subscription,
             subscription_is_active=subscription_is_active,
-            balance_kopeks=db_user.balance_kopeks
+            balance_kopeks=db_user.balance_kopeks,
+            subscription=db_user.subscription
         ),
         parse_mode="HTML"
     )

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -147,7 +147,8 @@ async def cmd_start(message: types.Message, state: FSMContext, db: AsyncSession,
                 has_had_paid_subscription=user.has_had_paid_subscription,
                 has_active_subscription=has_active_subscription,
                 subscription_is_active=subscription_is_active,
-                balance_kopeks=user.balance_kopeks 
+                balance_kopeks=user.balance_kopeks,
+                subscription=user.subscription
             ),
             parse_mode="HTML"
         )
@@ -448,7 +449,8 @@ async def complete_registration_from_callback(
                     has_had_paid_subscription=existing_user.has_had_paid_subscription,
                     has_active_subscription=has_active_subscription,
                     subscription_is_active=subscription_is_active,
-                    balance_kopeks=existing_user.balance_kopeks
+                    balance_kopeks=existing_user.balance_kopeks,
+                    subscription=existing_user.subscription
                 ),
                 parse_mode="HTML"
             )
@@ -563,7 +565,8 @@ async def complete_registration_from_callback(
                     has_had_paid_subscription=user.has_had_paid_subscription,
                     has_active_subscription=has_active_subscription,
                     subscription_is_active=subscription_is_active,
-                    balance_kopeks=user.balance_kopeks
+                    balance_kopeks=user.balance_kopeks,
+                    subscription=user.subscription
                 ),
                 parse_mode="HTML"
             )
@@ -611,7 +614,8 @@ async def complete_registration(
                     has_had_paid_subscription=existing_user.has_had_paid_subscription,
                     has_active_subscription=has_active_subscription,
                     subscription_is_active=subscription_is_active,
-                    balance_kopeks=existing_user.balance_kopeks
+                    balance_kopeks=existing_user.balance_kopeks,
+                    subscription=existing_user.subscription
                 ),
                 parse_mode="HTML"
             )
@@ -726,7 +730,8 @@ async def complete_registration(
                     has_had_paid_subscription=user.has_had_paid_subscription,
                     has_active_subscription=has_active_subscription,
                     subscription_is_active=subscription_is_active,
-                    balance_kopeks=user.balance_kopeks
+                    balance_kopeks=user.balance_kopeks,
+                    subscription=user.subscription
                 ),
                 parse_mode="HTML"
             )

--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -39,7 +39,8 @@ def get_main_menu_keyboard(
     has_had_paid_subscription: bool = False,
     has_active_subscription: bool = False,
     subscription_is_active: bool = False,
-    balance_kopeks: int = 0
+    balance_kopeks: int = 0,
+    subscription=None
 ) -> InlineKeyboardMarkup:
     texts = get_texts(language)
     
@@ -51,12 +52,43 @@ def get_main_menu_keyboard(
     else:
         balance_button_text = f"💰 Баланс: {texts.format_price(balance_kopeks)}"
     
-    keyboard = [
-        [
-            InlineKeyboardButton(text=balance_button_text, callback_data="menu_balance")
-        ]
-    ]
-    
+    keyboard = []
+
+    if has_active_subscription and subscription_is_active:
+        connect_mode = settings.CONNECT_BUTTON_MODE
+        if connect_mode == "miniapp_subscription":
+            keyboard.append([
+                InlineKeyboardButton(
+                    text="🔗 Подключиться",
+                    web_app=types.WebAppInfo(url=subscription.subscription_url)
+                )
+            ])
+        elif connect_mode == "miniapp_custom":
+            keyboard.append([
+                InlineKeyboardButton(
+                    text="🔗 Подключиться",
+                    web_app=types.WebAppInfo(url=settings.MINIAPP_CUSTOM_URL)
+                )
+            ])
+        elif connect_mode == "link":
+            keyboard.append([
+                InlineKeyboardButton(
+                    text="🔗 Подключиться",
+                    url=subscription.subscription_url
+                )
+            ])
+        else:
+            keyboard.append([
+                InlineKeyboardButton(
+                    text="🔗 Подключиться",
+                    callback_data="subscription_connect"
+                )
+            ])
+
+    keyboard.append([
+        InlineKeyboardButton(text=balance_button_text, callback_data="menu_balance")
+    ])
+
     if has_active_subscription and subscription_is_active:
         keyboard.append([
             InlineKeyboardButton(text=texts.MENU_SUBSCRIPTION, callback_data="menu_subscription")


### PR DESCRIPTION
## Summary
- show connect button in main menu when subscription is active
- pass subscription object to main menu keyboard calls

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5b12b168c8326a879d0827fa583c6