### PR TITLE
Add configurable RemnaWave user description template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,13 @@ REMNAWAVE_PASSWORD=
 # Для панелей установленных скриптом eGames прописывать ключ в формате XXXXXXX:DDDDDDDD
 REMNAWAVE_SECRET_KEY=
 
+# Шаблон описания пользователя в панели Remnawave
+# Доступные плейсхолдеры:
+#   {full_name}     — Имя, Фамилия из Telegram
+#   {username}       — Логин из Telegram (без @)
+#   {telegram_id}       — ID Telegram
+REMNAWAVE_USER_DESCRIPTION_TEMPLATE="Bot user: {full_name} @{username}"
+
 # ========= ПОДПИСКИ =========
 # ===== ТРИАЛ ПОДПИСКА =====
 TRIAL_DURATION_DAYS=3

--- a/.env.example
+++ b/.env.example
@@ -48,10 +48,11 @@ REMNAWAVE_SECRET_KEY=
 
 # Шаблон описания пользователя в панели Remnawave
 # Доступные плейсхолдеры:
-#   {full_name}     — Имя, Фамилия из Telegram
-#   {username}       — Логин из Telegram (без @)
+#   {full_name}         — Имя, Фамилия из Telegram
+#   {username}          — @логин из Telegram (c @)
+#   {username_clean}    — логин из Telegram (без @)
 #   {telegram_id}       — ID Telegram
-REMNAWAVE_USER_DESCRIPTION_TEMPLATE="Bot user: {full_name} @{username}"
+REMNAWAVE_USER_DESCRIPTION_TEMPLATE="Bot user: {full_name} {username}"
 
 # ========= ПОДПИСКИ =========
 # ===== ТРИАЛ ПОДПИСКА =====

--- a/app/config.py
+++ b/app/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     REMNAWAVE_USERNAME: Optional[str] = None
     REMNAWAVE_PASSWORD: Optional[str] = None
     REMNAWAVE_AUTH_TYPE: str = "api_key"
-    REMNAWAVE_USER_DESCRIPTION_TEMPLATE: str = "Bot user: {full_name} @{username}"
+    REMNAWAVE_USER_DESCRIPTION_TEMPLATE: str = "Bot user: {full_name} {username}"
     
     TRIAL_DURATION_DAYS: int = 3
     TRIAL_TRAFFIC_LIMIT_GB: int = 10
@@ -263,16 +263,20 @@ class Settings(BaseSettings):
         username: Optional[str],
         telegram_id: int
     ) -> str:
-        template = self.REMNAWAVE_USER_DESCRIPTION_TEMPLATE or "Bot user: {full_name} @{username}"
+        template = self.REMNAWAVE_USER_DESCRIPTION_TEMPLATE or "Bot user: {full_name} {username}"
+        template_for_formatting = template.replace("@{username}", "{username}")
+
+        username_clean = (username or "").lstrip("@")
         values = defaultdict(str, {
             "full_name": full_name,
-            "username": username or "",
+            "username": f"@{username_clean}" if username_clean else "",
+            "username_clean": username_clean,
             "telegram_id": str(telegram_id)
         })
 
-        description = template.format_map(values)
+        description = template_for_formatting.format_map(values)
 
-        if not username:
+        if not username_clean:
             description = re.sub(r'@(?=\W|$)', '', description)
             description = re.sub(r'\(\s*\)', '', description)
 

--- a/app/handlers/admin/users.py
+++ b/app/handlers/admin/users.py
@@ -1644,7 +1644,12 @@ async def toggle_user_server(
                 async with remnawave_service.api as api:
                     await api.update_user(
                         uuid=user.remnawave_uuid,
-                        active_internal_squads=current_squads
+                        active_internal_squads=current_squads,
+                        description=settings.format_remnawave_user_description(
+                            full_name=user.full_name,
+                            username=user.username,
+                            telegram_id=user.telegram_id
+                        )
                     )
                 logger.info(f"✅ Обновлены серверы в RemnaWave для пользователя {user.telegram_id}")
             except Exception as rw_error:
@@ -2023,7 +2028,12 @@ async def _update_user_devices(db: AsyncSession, user_id: int, devices: int, adm
                 async with remnawave_service.api as api:
                     await api.update_user(
                         uuid=user.remnawave_uuid,
-                        hwid_device_limit=devices
+                        hwid_device_limit=devices,
+                        description=settings.format_remnawave_user_description(
+                            full_name=user.full_name,
+                            username=user.username,
+                            telegram_id=user.telegram_id
+                        )
                     )
                 logger.info(f"✅ Обновлен лимит устройств в RemnaWave для пользователя {user.telegram_id}")
             except Exception as rw_error:
@@ -2061,7 +2071,12 @@ async def _update_user_traffic(db: AsyncSession, user_id: int, traffic_gb: int, 
                     await api.update_user(
                         uuid=user.remnawave_uuid,
                         traffic_limit_bytes=traffic_gb * (1024**3) if traffic_gb > 0 else 0,
-                        traffic_limit_strategy=TrafficLimitStrategy.MONTH
+                        traffic_limit_strategy=TrafficLimitStrategy.MONTH,
+                        description=settings.format_remnawave_user_description(
+                            full_name=user.full_name,
+                            username=user.username,
+                            telegram_id=user.telegram_id
+                        )
                     )
                 logger.info(f"✅ Обновлен лимит трафика в RemnaWave для пользователя {user.telegram_id}")
             except Exception as rw_error:

--- a/app/services/monitoring_service.py
+++ b/app/services/monitoring_service.py
@@ -158,8 +158,13 @@ class MonitoringService:
                     status=UserStatus.ACTIVE if is_active else UserStatus.EXPIRED,
                     expire_at=subscription.end_date,
                     traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                    traffic_limit_strategy=TrafficLimitStrategy.MONTH, 
+                    traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                     hwid_device_limit=subscription.device_limit,
+                    description=settings.format_remnawave_user_description(
+                        full_name=user.full_name,
+                        username=user.username,
+                        telegram_id=user.telegram_id
+                    ),
                     active_internal_squads=subscription.connected_squads
                 )
                 

--- a/app/services/remnawave_service.py
+++ b/app/services/remnawave_service.py
@@ -779,6 +779,11 @@ class RemnaWaveService:
                                 traffic_limit_bytes=subscription.traffic_limit_gb * (1024**3) if subscription.traffic_limit_gb > 0 else 0,
                                 traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                                 hwid_device_limit=subscription.device_limit,
+                                description=settings.format_remnawave_user_description(
+                                    full_name=user.full_name,
+                                    username=user.username,
+                                    telegram_id=user.telegram_id
+                                ),
                                 active_internal_squads=subscription.connected_squads
                             )
                             stats["updated"] += 1
@@ -793,7 +798,11 @@ class RemnaWaveService:
                                 traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                                 telegram_id=user.telegram_id,
                                 hwid_device_limit=subscription.device_limit,
-                                description=f"Bot user: {user.full_name}",
+                                description=settings.format_remnawave_user_description(
+                                    full_name=user.full_name,
+                                    username=user.username,
+                                    telegram_id=user.telegram_id
+                                ),
                                 active_internal_squads=subscription.connected_squads
                             )
                             

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -68,6 +68,11 @@ class SubscriptionService:
                         traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
                         traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                         hwid_device_limit=subscription.device_limit,
+                        description=settings.format_remnawave_user_description(
+                            full_name=user.full_name,
+                            username=user.username,
+                            telegram_id=user.telegram_id
+                        ),
                         active_internal_squads=subscription.connected_squads
                     )
                     
@@ -82,7 +87,11 @@ class SubscriptionService:
                         traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                         telegram_id=user.telegram_id,
                         hwid_device_limit=subscription.device_limit,
-                        description=f"Bot user: {user.full_name}",
+                        description=settings.format_remnawave_user_description(
+                            full_name=user.full_name,
+                            username=user.username,
+                            telegram_id=user.telegram_id
+                        ),
                         active_internal_squads=subscription.connected_squads
                     )
                 
@@ -135,8 +144,13 @@ class SubscriptionService:
                     status=UserStatus.ACTIVE if is_actually_active else UserStatus.EXPIRED,
                     expire_at=subscription.end_date,
                     traffic_limit_bytes=self._gb_to_bytes(subscription.traffic_limit_gb),
-                    traffic_limit_strategy=TrafficLimitStrategy.MONTH, 
+                    traffic_limit_strategy=TrafficLimitStrategy.MONTH,
                     hwid_device_limit=subscription.device_limit,
+                    description=settings.format_remnawave_user_description(
+                        full_name=user.full_name,
+                        username=user.username,
+                        telegram_id=user.telegram_id
+                    ),
                     active_internal_squads=subscription.connected_squads
                 )
                 


### PR DESCRIPTION
## Summary
- document the new RemnaWave user description template in the example environment file
- add settings support and formatter for the configurable RemnaWave user description template
- use the configurable description when creating users in RemnaWave services
- refresh RemnaWave user descriptions when calling `update_user`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8550513188326975083580d264f00