### PR TITLE
Schedule initial auto backup at configured time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -259,6 +259,8 @@ APP_CONFIG_CACHE_TTL=3600
 BACKUP_AUTO_ENABLED=true
 BACKUP_INTERVAL_HOURS=24
 BACKUP_TIME=03:00
+# Первый запуск автобекапа выполняется в ближайшее время BACKUP_TIME после старта бота,
+# далее копии создаются каждые BACKUP_INTERVAL_HOURS.
 BACKUP_MAX_KEEP=7
 BACKUP_COMPRESSION=true
 BACKUP_INCLUDE_LOGS=false

--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ APP_CONFIG_CACHE_TTL=3600
 BACKUP_AUTO_ENABLED=true
 BACKUP_INTERVAL_HOURS=24
 BACKUP_TIME=03:00
+# Первый запуск автобекапа выполняется в ближайшее время BACKUP_TIME после старта бота,
+# далее копии создаются каждые BACKUP_INTERVAL_HOURS.
 BACKUP_MAX_KEEP=7
 BACKUP_COMPRESSION=true
 BACKUP_INCLUDE_LOGS=false


### PR DESCRIPTION
## Summary
- schedule the first automatic backup run for the next BACKUP_TIME when the bot starts
- keep recurring runs on the configured BACKUP_INTERVAL_HOURS and validate invalid settings values
- document the updated scheduling behaviour in the configuration samples

## Testing
- python -m compileall app/services/backup_service.py

------
https://chatgpt.com/codex/tasks/task_e_68c90a88a00c83268d75166de29dbfd5