### PR TITLE
Hide zero-cost options from subscription pricing breakdown

### DIFF
--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -533,9 +533,12 @@ async def calculate_subscription_total_cost(
     
     logger.info(f"📊 Расчет стоимости подписки на {period_days} дней ({months_in_period} мес):")
     logger.info(f"   Базовый период: {base_price/100}₽")
-    logger.info(f"   Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_price/100}₽")
-    logger.info(f"   Серверы: {servers_price_per_month/100}₽/мес × {months_in_period} = {total_servers_price/100}₽")
-    logger.info(f"   Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_price/100}₽")
+    if total_traffic_price > 0:
+        logger.info(f"   Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_price/100}₽")
+    if total_servers_price > 0:
+        logger.info(f"   Серверы: {servers_price_per_month/100}₽/мес × {months_in_period} = {total_servers_price/100}₽")
+    if total_devices_price > 0:
+        logger.info(f"   Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_price/100}₽")
     logger.info(f"   ИТОГО: {total_cost/100}₽")
     
     return total_cost, details
@@ -646,9 +649,12 @@ async def get_subscription_renewal_cost(
         
         logger.info(f"💰 Расчет продления подписки {subscription_id} на {period_days} дней ({months_in_period} мес):")
         logger.info(f"   📅 Период: {base_price/100}₽")
-        logger.info(f"   🌍 Серверы: {servers_price_per_month/100}₽/мес × {months_in_period} = {total_servers_cost/100}₽")
-        logger.info(f"   📊 Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_cost/100}₽")
-        logger.info(f"   📱 Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_cost/100}₽")
+        if total_servers_cost > 0:
+            logger.info(f"   🌍 Серверы: {servers_price_per_month/100}₽/мес × {months_in_period} = {total_servers_cost/100}₽")
+        if total_traffic_cost > 0:
+            logger.info(f"   📊 Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_cost/100}₽")
+        if total_devices_cost > 0:
+            logger.info(f"   📱 Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_cost/100}₽")
         logger.info(f"   💎 ИТОГО: {total_cost/100}₽")
         
         return total_cost

--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -309,9 +309,12 @@ async def get_subscription_cost(subscription, db: AsyncSession) -> int:
         
         logger.info(f"📊 Месячная стоимость конфигурации подписки {subscription.id}:")
         logger.info(f"   📅 Базовый тариф (30 дней): {base_cost/100}₽")
-        logger.info(f"   🌍 Серверы: {servers_cost/100}₽")
-        logger.info(f"   📊 Трафик: {traffic_cost/100}₽")
-        logger.info(f"   📱 Устройства: {devices_cost/100}₽")
+        if servers_cost > 0:
+            logger.info(f"   🌍 Серверы: {servers_cost/100}₽")
+        if traffic_cost > 0:
+            logger.info(f"   📊 Трафик: {traffic_cost/100}₽")
+        if devices_cost > 0:
+            logger.info(f"   📱 Устройства: {devices_cost/100}₽")
         logger.info(f"   💎 ИТОГО: {total_cost/100}₽")
         
         return total_cost
@@ -1523,9 +1526,12 @@ async def confirm_extend_subscription(
         
         logger.info(f"💰 Расчет продления подписки {subscription.id} на {days} дней ({months_in_period} мес):")
         logger.info(f"   📅 Период {days} дней: {base_price/100}₽")
-        logger.info(f"   🌐 Серверы: {servers_price_per_month/100}₽/мес × {months_in_period} = {total_servers_price/100}₽")
-        logger.info(f"   📱 Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_price/100}₽")
-        logger.info(f"   📊 Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_price/100}₽")
+        if total_servers_price > 0:
+            logger.info(f"   🌐 Серверы: {servers_price_per_month/100}₽/мес × {months_in_period} = {total_servers_price/100}₽")
+        if total_devices_price > 0:
+            logger.info(f"   📱 Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_price/100}₽")
+        if total_traffic_price > 0:
+            logger.info(f"   📊 Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_price/100}₽")
         logger.info(f"   💎 ИТОГО: {price/100}₽")
         
     except Exception as e:
@@ -2078,24 +2084,33 @@ async def devices_continue(
         else:
             traffic_display = f"{data['traffic_gb']} ГБ"
     
-    summary_text = f"""
-📋 <b>Сводка заказа</b>
+    details_lines = [f"- Базовый период: {texts.format_price(base_price)}"]
+    if total_traffic_price > 0:
+        details_lines.append(
+            f"- Трафик: {texts.format_price(traffic_price_per_month)}/мес × {months_in_period} = {texts.format_price(total_traffic_price)}"
+        )
+    if total_countries_price > 0:
+        details_lines.append(
+            f"- Серверы: {texts.format_price(countries_price_per_month)}/мес × {months_in_period} = {texts.format_price(total_countries_price)}"
+        )
+    if total_devices_price > 0:
+        details_lines.append(
+            f"- Доп. устройства: {texts.format_price(devices_price_per_month)}/мес × {months_in_period} = {texts.format_price(total_devices_price)}"
+        )
 
-📅 <b>Период:</b> {period_display}
-📊 <b>Трафик:</b> {traffic_display}
-🌍 <b>Страны:</b> {", ".join(selected_countries_names)}
-📱 <b>Устройства:</b> {data['devices']}
+    details_text = "\n".join(details_lines)
 
-💰 <b>Детализация стоимости:</b>
-- Базовый период: {texts.format_price(base_price)}
-- Трафик: {texts.format_price(traffic_price_per_month)}/мес × {months_in_period} = {texts.format_price(total_traffic_price)}
-- Серверы: {texts.format_price(countries_price_per_month)}/мес × {months_in_period} = {texts.format_price(total_countries_price)}
-- Доп. устройства: {texts.format_price(devices_price_per_month)}/мес × {months_in_period} = {texts.format_price(total_devices_price)}
-
-💎 <b>Общая стоимость:</b> {texts.format_price(total_price)}
-
-Подтверждаете покупку?
-"""
+    summary_text = (
+        "📋 <b>Сводка заказа</b>\n\n"
+        f"📅 <b>Период:</b> {period_display}\n"
+        f"📊 <b>Трафик:</b> {traffic_display}\n"
+        f"🌍 <b>Страны:</b> {', '.join(selected_countries_names)}\n"
+        f"📱 <b>Устройства:</b> {data['devices']}\n\n"
+        "💰 <b>Детализация стоимости:</b>\n"
+        f"{details_text}\n\n"
+        f"💎 <b>Общая стоимость:</b> {texts.format_price(total_price)}\n\n"
+        "Подтверждаете покупку?"
+    )
     
     await callback.message.edit_text(
         summary_text,
@@ -2161,9 +2176,12 @@ async def confirm_purchase(
     
     logger.info(f"Расчет покупки подписки на {data['period_days']} дней ({months_in_period} мес):")
     logger.info(f"   Период: {base_price/100}₽")
-    logger.info(f"   Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_price/100}₽")
-    logger.info(f"   Серверы: {countries_price_per_month/100}₽/мес × {months_in_period} = {total_countries_price/100}₽")
-    logger.info(f"   Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_price/100}₽")
+    if total_traffic_price > 0:
+        logger.info(f"   Трафик: {traffic_price_per_month/100}₽/мес × {months_in_period} = {total_traffic_price/100}₽")
+    if total_countries_price > 0:
+        logger.info(f"   Серверы: {countries_price_per_month/100}₽/мес × {months_in_period} = {total_countries_price/100}₽")
+    if total_devices_price > 0:
+        logger.info(f"   Устройства: {devices_price_per_month/100}₽/мес × {months_in_period} = {total_devices_price/100}₽")
     logger.info(f"   ИТОГО: {final_price/100}₽")
     
     if db_user.balance_kopeks < final_price:

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -283,9 +283,12 @@ class SubscriptionService:
         
         logger.info(f"Расчет стоимости новой подписки:")
         logger.info(f"   Период {period_days} дней: {base_price/100}₽")
-        logger.info(f"   Трафик {traffic_gb} ГБ: {traffic_price/100}₽")
-        logger.info(f"   Серверы ({len(server_squad_ids)}): {total_servers_price/100}₽")
-        logger.info(f"   Устройства ({devices}): {devices_price/100}₽")
+        if traffic_price > 0:
+            logger.info(f"   Трафик {traffic_gb} ГБ: {traffic_price/100}₽")
+        if total_servers_price > 0:
+            logger.info(f"   Серверы ({len(server_squad_ids)}): {total_servers_price/100}₽")
+        if devices_price > 0:
+            logger.info(f"   Устройства ({devices}): {devices_price/100}₽")
         logger.info(f"   ИТОГО: {total_price/100}₽")
         
         return total_price, server_prices
@@ -313,9 +316,12 @@ class SubscriptionService:
             
             logger.info(f"💰 Расчет стоимости продления для подписки {subscription.id} (по текущим ценам):")
             logger.info(f"   📅 Период {period_days} дней: {base_price/100}₽")
-            logger.info(f"   🌍 Серверы ({len(subscription.connected_squads)}) по текущим ценам: {servers_price/100}₽")
-            logger.info(f"   📱 Устройства ({subscription.device_limit}): {devices_price/100}₽")
-            logger.info(f"   📊 Трафик ({subscription.traffic_limit_gb} ГБ): {traffic_price/100}₽")
+            if servers_price > 0:
+                logger.info(f"   🌍 Серверы ({len(subscription.connected_squads)}) по текущим ценам: {servers_price/100}₽")
+            if devices_price > 0:
+                logger.info(f"   📱 Устройства ({subscription.device_limit}): {devices_price/100}₽")
+            if traffic_price > 0:
+                logger.info(f"   📊 Трафик ({subscription.traffic_limit_gb} ГБ): {traffic_price/100}₽")
             logger.info(f"   💎 ИТОГО: {total_price/100}₽")
             
             return total_price
@@ -458,9 +464,16 @@ class SubscriptionService:
         
         logger.info(f"Расчет стоимости новой подписки на {period_days} дней ({months_in_period} мес):")
         logger.info(f"   Период {period_days} дней: {base_price/100}₽")
-        logger.info(f"   Трафик {traffic_gb} ГБ: {traffic_price_per_month/100}₽/мес x {months_in_period} = {total_traffic_price/100}₽")
-        logger.info(f"   Серверы ({len(server_squad_ids)}): {total_servers_price/100}₽")
-        logger.info(f"   Устройства ({additional_devices}): {devices_price_per_month/100}₽/мес x {months_in_period} = {total_devices_price/100}₽")
+        if total_traffic_price > 0:
+            logger.info(
+                f"   Трафик {traffic_gb} ГБ: {traffic_price_per_month/100}₽/мес x {months_in_period} = {total_traffic_price/100}₽"
+            )
+        if total_servers_price > 0:
+            logger.info(f"   Серверы ({len(server_squad_ids)}): {total_servers_price/100}₽")
+        if total_devices_price > 0:
+            logger.info(
+                f"   Устройства ({additional_devices}): {devices_price_per_month/100}₽/мес x {months_in_period} = {total_devices_price/100}₽"
+            )
         logger.info(f"   ИТОГО: {total_price/100}₽")
         
         return total_price, server_prices
@@ -494,9 +507,18 @@ class SubscriptionService:
             
             logger.info(f"💰 Расчет стоимости продления подписки {subscription.id} на {period_days} дней ({months_in_period} мес):")
             logger.info(f"   📅 Период {period_days} дней: {base_price/100}₽")
-            logger.info(f"   🌍 Серверы: {servers_price_per_month/100}₽/мес x {months_in_period} = {total_servers_price/100}₽")
-            logger.info(f"   📱 Устройства: {devices_price_per_month/100}₽/мес x {months_in_period} = {total_devices_price/100}₽")
-            logger.info(f"   📊 Трафик: {traffic_price_per_month/100}₽/мес x {months_in_period} = {total_traffic_price/100}₽")
+            if total_servers_price > 0:
+                logger.info(
+                    f"   🌍 Серверы: {servers_price_per_month/100}₽/мес x {months_in_period} = {total_servers_price/100}₽"
+                )
+            if total_devices_price > 0:
+                logger.info(
+                    f"   📱 Устройства: {devices_price_per_month/100}₽/мес x {months_in_period} = {total_devices_price/100}₽"
+                )
+            if total_traffic_price > 0:
+                logger.info(
+                    f"   📊 Трафик: {traffic_price_per_month/100}₽/мес x {months_in_period} = {total_traffic_price/100}₽"
+                )
             logger.info(f"   💎 ИТОГО: {total_price/100}₽")
             
             return total_price


### PR DESCRIPTION
## Summary
- hide zero-cost traffic, server, and device line items in subscription pricing calculations across services and handlers
- update subscription purchase summary text to omit zero-cost options from the pricing breakdown

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9e56559388326abc6a317615bdff3