### PR TITLE
Fix subscription success text formatting

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -2396,9 +2396,14 @@ async def confirm_purchase(
         await db.refresh(subscription)
         
         if remnawave_user and hasattr(subscription, 'subscription_url') and subscription.subscription_url:
+            import_link_section = texts.t(
+                "SUBSCRIPTION_IMPORT_LINK_SECTION",
+                "🔗 <b>Ваша ссылка для импорта в VPN приложение:</b>\\n<code>{subscription_url}</code>",
+            ).format(subscription_url=subscription.subscription_url)
+
             success_text = (
                 f"{texts.SUBSCRIPTION_PURCHASED}\n\n"
-                f"{texts.t('SUBSCRIPTION_IMPORT_LINK_SECTION', '🔗 <b>Ваша ссылка для импорта в VPN приложение:</b>\\n<code>{subscription_url}</code>').format(subscription_url=subscription.subscription_url)}\n\n"
+                f"{import_link_section}\n\n"
                 f"{texts.t('SUBSCRIPTION_IMPORT_INSTRUCTION_PROMPT', '📱 Нажмите кнопку ниже, чтобы получить инструкцию по настройке VPN на вашем устройстве')}"
             )
 


### PR DESCRIPTION
## Summary
- compute the subscription import link text separately before composing the success message
- avoid using a formatted string inside the f-string expression to prevent syntax errors

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd23aee6088326a04ece758b3a7f9f