### PR TITLE
Ensure trial-to-paid upgrade defaults to paid device limit

### DIFF
--- a/app/handlers/subscription.py
+++ b/app/handlers/subscription.py
@@ -612,11 +612,17 @@ async def start_subscription_purchase(
         texts.BUY_SUBSCRIPTION_START,
         reply_markup=get_subscription_period_keyboard(db_user.language)
     )
-    
+
+    subscription = getattr(db_user, 'subscription', None)
+    initial_devices = settings.DEFAULT_DEVICE_LIMIT
+
+    if subscription and getattr(subscription, 'device_limit', None):
+        initial_devices = max(settings.DEFAULT_DEVICE_LIMIT, subscription.device_limit)
+
     initial_data = {
         'period_days': None,
         'countries': [],
-        'devices': settings.DEFAULT_DEVICE_LIMIT, 
+        'devices': initial_devices,
         'total_price': 0
     }
     
@@ -1994,9 +2000,11 @@ async def select_period(
             data['countries'] = [available_countries[0]['uuid']] if available_countries else []
             await state.set_data(data)
             
+            selected_devices = data.get('devices', settings.DEFAULT_DEVICE_LIMIT)
+
             await callback.message.edit_text(
                 texts.SELECT_DEVICES,
-                reply_markup=get_devices_keyboard(1, db_user.language)
+                reply_markup=get_devices_keyboard(selected_devices, db_user.language)
             )
             await state.set_state(SubscriptionStates.selecting_devices)
     
@@ -2148,9 +2156,11 @@ async def select_traffic(
         data['countries'] = [available_countries[0]['uuid']] if available_countries else []
         await state.set_data(data)
         
+        selected_devices = data.get('devices', settings.DEFAULT_DEVICE_LIMIT)
+
         await callback.message.edit_text(
             texts.SELECT_DEVICES,
-            reply_markup=get_devices_keyboard(1, db_user.language)
+            reply_markup=get_devices_keyboard(selected_devices, db_user.language)
         )
         await state.set_state(SubscriptionStates.selecting_devices)
     
@@ -2206,9 +2216,11 @@ async def countries_continue(
         await callback.answer("⚠️ Выберите хотя бы одну страну!", show_alert=True)
         return
     
+    selected_devices = data.get('devices', settings.DEFAULT_DEVICE_LIMIT)
+
     await callback.message.edit_text(
         texts.SELECT_DEVICES,
-        reply_markup=get_devices_keyboard(1, db_user.language)
+        reply_markup=get_devices_keyboard(selected_devices, db_user.language)
     )
     
     await state.set_state(SubscriptionStates.selecting_devices)


### PR DESCRIPTION
## Summary
- initialize subscription purchase state with the greater of DEFAULT_DEVICE_LIMIT and the current subscription limit
- reuse the stored device selection when showing the devices keyboard so trial upgrades default to the paid limit

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd7587c4dc8326828b91d087a8285e