### PR TITLE
Reorder subscription return button in top-up selection

### DIFF
--- a/app/keyboards/inline.py
+++ b/app/keyboards/inline.py
@@ -392,28 +392,31 @@ def get_insufficient_balance_keyboard(
     texts = get_texts(language)
     keyboard = get_payment_methods_keyboard(amount_kopeks or 0, language)
 
-    if resume_callback:
-        keyboard.inline_keyboard.insert(
-            0,
-            [
-                InlineKeyboardButton(
-                    text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
-                    callback_data=resume_callback,
-                )
-            ],
-        )
+    back_row_index: int | None = None
 
     if keyboard.inline_keyboard:
         last_row = keyboard.inline_keyboard[-1]
         if (
             len(last_row) == 1
             and isinstance(last_row[0], InlineKeyboardButton)
-            and last_row[0].callback_data == "menu_balance"
+            and last_row[0].callback_data in {"menu_balance", "back_to_menu"}
         ):
             keyboard.inline_keyboard[-1][0] = InlineKeyboardButton(
-                text=last_row[0].text,
+                text=texts.t("PAYMENT_RETURN_HOME_BUTTON", "🏠 На главную"),
                 callback_data="back_to_menu",
             )
+            back_row_index = len(keyboard.inline_keyboard) - 1
+
+    if resume_callback:
+        return_row = [
+            InlineKeyboardButton(
+                text=texts.RETURN_TO_SUBSCRIPTION_CHECKOUT,
+                callback_data=resume_callback,
+            )
+        ]
+
+        insert_index = back_row_index if back_row_index is not None else len(keyboard.inline_keyboard)
+        keyboard.inline_keyboard.insert(insert_index, return_row)
 
     return keyboard
 

--- a/app/localization/locales/en.json
+++ b/app/localization/locales/en.json
@@ -412,6 +412,7 @@
   "PAYMENT_METHODS_TITLE": "💳 <b>Balance top-up methods</b>",
   "PAYMENT_METHODS_PROMPT": "Choose the payment method that suits you:",
   "PAYMENT_METHODS_FOOTER": "Choose a top-up method:",
+  "PAYMENT_RETURN_HOME_BUTTON": "🏠 Main menu",
   "PAYMENT_METHOD_STARS_NAME": "⭐ <b>Telegram Stars</b>",
   "PAYMENT_METHOD_STARS_DESCRIPTION": "fast and convenient",
   "PAYMENT_METHOD_YOOKASSA_NAME": "💳 <b>Bank card</b>",

--- a/app/localization/locales/ru.json
+++ b/app/localization/locales/ru.json
@@ -414,6 +414,7 @@
   "PAYMENT_METHODS_TITLE": "💳 <b>Способы пополнения баланса</b>",
   "PAYMENT_METHODS_PROMPT": "Выберите удобный для вас способ оплаты:",
   "PAYMENT_METHODS_FOOTER": "Выберите способ пополнения:",
+  "PAYMENT_RETURN_HOME_BUTTON": "🏠 На главную",
   "PAYMENT_METHOD_STARS_NAME": "⭐ <b>Telegram Stars</b>",
   "PAYMENT_METHOD_STARS_DESCRIPTION": "быстро и удобно",
   "PAYMENT_METHOD_YOOKASSA_NAME": "💳 <b>Банковская карта</b>",

--- a/locales/en.json
+++ b/locales/en.json
@@ -498,6 +498,7 @@
   "PAYMENT_METHODS_TITLE": "💳 <b>Balance top-up methods</b>",
   "PAYMENT_METHODS_PROMPT": "Choose the payment method that suits you:",
   "PAYMENT_METHODS_FOOTER": "Choose a top-up method:",
+  "PAYMENT_RETURN_HOME_BUTTON": "🏠 Main menu",
   "PAYMENT_METHOD_STARS_NAME": "⭐ <b>Telegram Stars</b>",
   "PAYMENT_METHOD_STARS_DESCRIPTION": "fast and convenient",
   "PAYMENT_METHOD_YOOKASSA_NAME": "💳 <b>Bank card</b>",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -498,6 +498,7 @@
   "PAYMENT_METHODS_TITLE": "💳 <b>Способы пополнения баланса</b>",
   "PAYMENT_METHODS_PROMPT": "Выберите удобный для вас способ оплаты:",
   "PAYMENT_METHODS_FOOTER": "Выберите способ пополнения:",
+  "PAYMENT_RETURN_HOME_BUTTON": "🏠 На главную",
   "PAYMENT_METHOD_STARS_NAME": "⭐ <b>Telegram Stars</b>",
   "PAYMENT_METHOD_STARS_DESCRIPTION": "быстро и удобно",
   "PAYMENT_METHOD_YOOKASSA_NAME": "💳 <b>Банковская карта</b>",


### PR DESCRIPTION
## Summary
- move the "return to subscription" button below the list of payment methods when displaying the insufficient balance keyboard
- rename the back-to-menu control to "🏠 На главную" and add localized strings for the new label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e915938083268da61c1de8cf5d14